### PR TITLE
Support multiple globs as input for exclude in multiline mode

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -575,6 +575,7 @@ def _parse_autopep_exclude_arg(
     parser.add_argument(
         "--exclude",
         metavar='globs',
+        nargs='*',
         required=False
     )
 

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -556,7 +556,8 @@ def _to_run_result_with_logging(rpc_result: jsonrpc.RpcRunResult) -> utils.RunRe
 
 def _is_file_in_excluded_pattern(file_path: str, exclude_arg) -> bool:
     if exclude_arg.exclude is not None:
-        exclude_patterns = _split_comma_separated(exclude_arg.exclude)
+        exclude_string = ', '.join(exclude_arg.exclude)
+        exclude_patterns = _split_comma_separated(exclude_string)
 
         for pattern in exclude_patterns:
             if fnmatch.fnmatch(file_path, pattern):

--- a/src/test/python_tests/test_data/sample5/exclude_dir1/sample.unformatted
+++ b/src/test/python_tests/test_data/sample5/exclude_dir1/sample.unformatted
@@ -1,0 +1,2 @@
+import sys;print(sys.executable)
+# There is intentionally no last empty line.

--- a/src/test/python_tests/test_data/sample5/exclude_dir2/sample.unformatted
+++ b/src/test/python_tests/test_data/sample5/exclude_dir2/sample.unformatted
@@ -1,0 +1,2 @@
+import sys;print(sys.executable)
+# There is intentionally no last empty line.

--- a/src/test/python_tests/test_formatting.py
+++ b/src/test/python_tests/test_formatting.py
@@ -180,99 +180,152 @@ def test_skipping_excluded_files():
     expected = None
     assert_that(actual, is_(expected))
 
-    def test_formatting_file_not_in_excluded_files():
-        """Test formatting when the file is not in excluded pattern"""
-        FORMATTED_TEST_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.py"
-        UNFORMATTED_INCLUDED_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.included.unformatted"
+def test_formatting_file_not_in_excluded_files():
+    """Test formatting when the file is not in excluded pattern"""
+    FORMATTED_TEST_FILE_PATH = constants.TEST_DATA / "sample4" / "sample_formatted.py"
+    UNFORMATTED_INCLUDED_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.included.unformatted"
 
-        contents = UNFORMATTED_INCLUDED_FILE_PATH.read_text()
-        lines = contents.splitlines(keepends=False)
+    contents = UNFORMATTED_INCLUDED_FILE_PATH.read_text()
+    lines = contents.splitlines(keepends=False)
 
-        with utils.python_file(contents, UNFORMATTED_INCLUDED_FILE_PATH.parent) as pf:
-            with session.LspSession() as ls_session:
-                # Use any stdlib path here
-                uri = utils.as_uri(str(pf))
+    with utils.python_file(contents, UNFORMATTED_INCLUDED_FILE_PATH.parent) as pf:
+        with session.LspSession() as ls_session:
+            # Use any stdlib path here
+            uri = utils.as_uri(str(pf))
 
-                init_args = copy.deepcopy(defaults.VSCODE_DEFAULT_INITIALIZE)
-                init_options = init_args["initializationOptions"]
-                init_options["settings"][0]["args"] = ["--exclude=**/*exclude"]
-                ls_session.initialize(init_args)
+            init_args = copy.deepcopy(defaults.VSCODE_DEFAULT_INITIALIZE)
+            init_options = init_args["initializationOptions"]
+            init_options["settings"][0]["args"] = ["--exclude=**/*exclude"]
+            ls_session.initialize(init_args)
 
-                ls_session.notify_did_open(
-                    {
-                        "textDocument": {
-                            "uri": uri,
-                            "languageId": "python",
-                            "version": 1,
-                            "text": UNFORMATTED_INCLUDED_FILE_PATH.read_text(encoding="utf-8"),
-                        }
+            ls_session.notify_did_open(
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": "python",
+                        "version": 1,
+                        "text": UNFORMATTED_INCLUDED_FILE_PATH.read_text(encoding="utf-8"),
                     }
-                )
-
-                actual = ls_session.text_document_formatting(
-                    {
-                        "textDocument": {"uri": uri},
-                        # `options` is not used by black
-                        "options": {"tabSize": 4, "insertSpaces": True},
-                    }
-                )
-
-        expected = [
-            {
-                "range": {
-                    "start": {"line": 0, "character": 0},
-                    "end": {"line": len(lines), "character": 0},
-                    },
-                "newText": FORMATTED_TEST_FILE_PATH.read_text(),
                 }
-            ]
-        assert_that(actual, is_(expected))
+            )
 
-    def test_formatting_file_with_excluded_and_other_args():
-        """Test formatting when we have more arguments specified"""
-        FORMATTED_TEST_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.py"
-        UNFORMATTED_INCLUDED_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.included.unformatted"
-
-        contents = UNFORMATTED_INCLUDED_FILE_PATH.read_text()
-        lines = contents.splitlines(keepends=False)
-
-        with utils.python_file(contents, UNFORMATTED_INCLUDED_FILE_PATH.parent) as pf:
-
-            with session.LspSession() as ls_session:
-                # Use any stdlib path here
-                uri = utils.as_uri(str(pf))
-
-                init_args = copy.deepcopy(defaults.VSCODE_DEFAULT_INITIALIZE)
-                init_options = init_args["initializationOptions"]
-                init_options["settings"][0]["args"] = ["--exclude=**/*exclude", "--aggressive"]
-                ls_session.initialize(init_args)
-
-                ls_session.notify_did_open(
-                    {
-                        "textDocument": {
-                            "uri": uri,
-                            "languageId": "python",
-                            "version": 1,
-                            "text": UNFORMATTED_INCLUDED_FILE_PATH.read_text(encoding="utf-8"),
-                        }
-                    }
-                )
-
-                actual = ls_session.text_document_formatting(
-                    {
-                        "textDocument": {"uri": uri},
-                        # `options` is not used by black
-                        "options": {"tabSize": 4, "insertSpaces": True},
-                    }
-                )
-
-        expected = [
-            {
-                "range": {
-                    "start": {"line": 0, "character": 0},
-                    "end": {"line": len(lines), "character": 0},
-                    },
-                "newText": FORMATTED_TEST_FILE_PATH.read_text(),
+            actual = ls_session.text_document_formatting(
+                {
+                    "textDocument": {"uri": uri},
+                    # `options` is not used by black
+                    "options": {"tabSize": 4, "insertSpaces": True},
                 }
-            ]
-        assert_that(actual, is_(expected))
+            )
+
+    expected = [
+        {
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": len(lines), "character": 0},
+                },
+            "newText": FORMATTED_TEST_FILE_PATH.read_text(),
+            }
+        ]
+    assert_that(actual, is_(expected))
+
+def test_formatting_file_with_excluded_and_other_args():
+    """Test formatting when we have more arguments specified"""
+    FORMATTED_TEST_FILE_PATH = constants.TEST_DATA / "sample4" / "sample_formatted.py"
+    UNFORMATTED_INCLUDED_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.included.unformatted"
+
+    contents = UNFORMATTED_INCLUDED_FILE_PATH.read_text()
+    lines = contents.splitlines(keepends=False)
+
+    with utils.python_file(contents, UNFORMATTED_INCLUDED_FILE_PATH.parent) as pf:
+
+        with session.LspSession() as ls_session:
+            # Use any stdlib path here
+            uri = utils.as_uri(str(pf))
+
+            init_args = copy.deepcopy(defaults.VSCODE_DEFAULT_INITIALIZE)
+            init_options = init_args["initializationOptions"]
+            init_options["settings"][0]["args"] = ["--exclude=**/*exclude", "--aggressive"]
+            ls_session.initialize(init_args)
+
+            ls_session.notify_did_open(
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": "python",
+                        "version": 1,
+                        "text": UNFORMATTED_INCLUDED_FILE_PATH.read_text(encoding="utf-8"),
+                    }
+                }
+            )
+
+            actual = ls_session.text_document_formatting(
+                {
+                    "textDocument": {"uri": uri},
+                    # `options` is not used by black
+                    "options": {"tabSize": 4, "insertSpaces": True},
+                }
+            )
+
+    expected = [
+        {
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": len(lines), "character": 0},
+                },
+            "newText": FORMATTED_TEST_FILE_PATH.read_text(),
+            }
+        ]
+    assert_that(actual, is_(expected))
+
+def test_formatting_file_with_excluded_with_multiple_globs():
+    """Test formatting when we have more arguments specified"""
+    FORMATTED_TEST_FILE_PATH = constants.TEST_DATA / "sample4" / "sample_formatted.py"
+    UNFORMATTED_INCLUDED_FILE_PATH = constants.TEST_DATA / "sample4" / "sample.included.unformatted"
+
+    UNFORMATTED_EXCLUDE_FILEPATH_1 = constants.TEST_DATA / "sample5" / "exclude_dir1" / "sample.unformatted"
+    UNFORMATTED_EXCLUDE_FILEPATH_2 = constants.TEST_DATA / "sample5" / "exclude_dir2" / "sample.unformatted"
+
+
+    contents = UNFORMATTED_INCLUDED_FILE_PATH.read_text()
+    lines = contents.splitlines(keepends=False)
+
+    with utils.python_file(contents, UNFORMATTED_INCLUDED_FILE_PATH.parent) as pf:
+
+        with session.LspSession() as ls_session:
+            # Use any stdlib path here
+            uri = utils.as_uri(str(pf))
+
+            init_args = copy.deepcopy(defaults.VSCODE_DEFAULT_INITIALIZE)
+            init_options = init_args["initializationOptions"]
+            init_options["settings"][0]["args"] = ["--exclude", "**/exclude_dir1/*.py", "**/exclude_dir2/*.py", "--aggressive"]
+            ls_session.initialize(init_args)
+
+            ls_session.notify_did_open(
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": "python",
+                        "version": 1,
+                        "text": UNFORMATTED_INCLUDED_FILE_PATH.read_text(encoding="utf-8"),
+                    }
+                }
+            )
+
+            actual = ls_session.text_document_formatting(
+                {
+                    "textDocument": {"uri": uri},
+                    # `options` is not used by black
+                    "options": {"tabSize": 4, "insertSpaces": True},
+                }
+            )
+
+    expected = [
+        {
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": len(lines), "character": 0},
+                },
+            "newText": FORMATTED_TEST_FILE_PATH.read_text(),
+            }
+        ]
+    assert_that(actual, is_(expected))


### PR DESCRIPTION
There's one more bug I found. If we have multiple `globs` as separate strings in the list, only first part is considered for the pattern. We should use `nargs` argument to process all patterns.