### PR TITLE
Update serviceTreeID to Pylance team

### DIFF
--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -65,8 +65,8 @@ extends:
 
     tsa:
       config:
-        areaPath: 'Visual Studio Code Python Extensions'
-        serviceTreeID: '6e6194bc-7baa-4486-86d0-9f5419626d46'
+        areaPath: 'Pylance'
+        serviceTreeID: 'e3c408e8-09e7-404f-a9af-22b4ac3807a3'
       enabled: true
 
     publishExtension: ${{ parameters.publishExtension }}

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -60,6 +60,6 @@ extends:
         displayName: Build extension
     tsa:
       config:
-        areaPath: 'Visual Studio Code Python Extensions'
-        serviceTreeID: '6e6194bc-7baa-4486-86d0-9f5419626d46'
+        areaPath: 'Pylance'
+        serviceTreeID: 'e3c408e8-09e7-404f-a9af-22b4ac3807a3'
       enabled: true


### PR DESCRIPTION
## Summary
This PR updates the serviceTreeID and areaPath for the Pylance team migration.

## Changes
- **serviceTreeID**: `6e6194bc-7baa-4486-86d0-9f5419626d46` → `e3c408e8-09e7-404f-a9af-22b4ac3807a3`
- **areaPath**: Updated to `Pylance`

## Files Updated
- `build/azure-pipeline.stable.yml`
- `build/azure-pipeline.pre-release.yml`

## Context
Part of the Pylance team service tree migration across Python extension repositories.
