### PR TITLE
Fix stable pipeline trigger to only use tags

### DIFF
--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -18,7 +18,7 @@ Start by reading `package.json` to determine the current version. Then confirm w
 
 - **Even minor** = stable release (e.g. `2026.4.0` — *example*)
 - **Odd minor** = pre-release / dev (e.g. `2026.3.0-dev`, `2026.5.0-dev` — *examples*)
-- The stable release pipeline (`build/azure-devdiv-pipeline.stable.yml`) triggers on git tags matching `refs/tags/*`
+- The stable release pipeline (`build/azure-devdiv-pipeline.stable.yml`) triggers on git tags matching `refs/tags/v*`
 - Tag format: `v<version>` (e.g. `v2026.4.0` — *example*)
 - Release branch format: `release/<YYYY>.<EVEN_MINOR>` (e.g. `release/2026.4` — *example*)
 

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -1,8 +1,5 @@
 name: Publish Release
 trigger:
-  branches:
-    include:
-      - release*
   tags:
     include: ['*']
 pr: none

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -1,7 +1,7 @@
 name: Publish Release
 trigger:
   tags:
-    include: ['*']
+    include: ['v*']
 pr: none
 
 resources:


### PR DESCRIPTION
Remove branch trigger from stable pipeline - only tags should trigger the publish pipeline to avoid duplicate runs.